### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ temp*/
 *.tar
 *.toc
 *.zip
+.github

--- a/TRAiNER.spec.default
+++ b/TRAiNER.spec.default
@@ -1,14 +1,17 @@
 # -*- mode: python ; coding: utf-8 -*-
 
-
 block_cipher = None
 
 
 a = Analysis(
     ['tmp\\launch.py'],
-    pathex=[],
+    pathex=['.\\app'],
     binaries=[],
-    datas=[('.\\assets\\ff7r.png', '.')],
+    datas=[('.\\assets\\ff7r.png', '.'),
+        #('.\\app\\gui.py', '.'),
+        #('.\\app\\settings.py', '.'),
+        #('.\\app\\offsets.py', '.'),
+    ],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/app/gui.py
+++ b/app/gui.py
@@ -962,6 +962,8 @@ class PartyMember():
 ### GUI
 
 class CheatTrainer():
+    ''' The main GUI window. '''
+
     def __init__(self, window_title):
 
         self.is_hidden: cython.bint = False #For window hiding

--- a/app/gui.py
+++ b/app/gui.py
@@ -163,8 +163,6 @@ def timed_cache(**timedelta_kwargs):
 
     def _wrapper(f):
         update_delta = timedelta(**timedelta_kwargs)
-        #next_update = datetime.utcnow() + update_delta
-        # datetime.datetime.utcnow() is deprecated.
         next_update = datetime.now() + update_delta
         # Apply @lru_cache to f with no cache size limit
         f = functools.lru_cache(None)(f)
@@ -172,7 +170,6 @@ def timed_cache(**timedelta_kwargs):
         @functools.wraps(f)
         def _wrapped(*args, **kwargs):
             nonlocal next_update
-            #now = datetime.utcnow() #datetime.datetime.utcnow() is deprecated.
             now = datetime.now()
             if now >= next_update:
                 f.cache_clear()

--- a/app/gui.py
+++ b/app/gui.py
@@ -163,14 +163,17 @@ def timed_cache(**timedelta_kwargs):
 
     def _wrapper(f):
         update_delta = timedelta(**timedelta_kwargs)
-        next_update = datetime.utcnow() + update_delta
+        #next_update = datetime.utcnow() + update_delta
+        # datetime.datetime.utcnow() is deprecated.
+        next_update = datetime.now() + update_delta
         # Apply @lru_cache to f with no cache size limit
         f = functools.lru_cache(None)(f)
 
         @functools.wraps(f)
         def _wrapped(*args, **kwargs):
             nonlocal next_update
-            now = datetime.utcnow()
+            #now = datetime.utcnow() #datetime.datetime.utcnow() is deprecated.
+            now = datetime.now()
             if now >= next_update:
                 f.cache_clear()
                 next_update = now + update_delta

--- a/app/settings.py
+++ b/app/settings.py
@@ -8,11 +8,12 @@ GAME_VERSION = 'epic'
 
 ### APPEARANCE OPTIONS ###
 class Appearance:
+    ''' General appearance options. '''
     # Transparent background
-    TRANSPARENT_BG = False
-    SHOW_IMAGE = True
+    TRANSPARENT_BG = True
+    SHOW_IMAGE = False
     HEADER_IMG_PATH = 'assets/ff7r.png'
-    ALPHA = 0.8
+    ALPHA = 1.0
     FRAMELESS_WINDOW = True
 
     # Colors
@@ -43,7 +44,7 @@ class Appearance:
         'FONT_SIZE_TITLE': '12',
     }
 
-    # Time to display error messages/highlight labels on cheat usage.
+    # Time to display error messages/highlight labels on cheat usage (seconds).
     FEEDBACK_COOLDOWN = 2
 
 ### HOTKEYS ###

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,36 @@
 
 A cheat trainer for FF7 Remake Intergrade.
 
+```
+ ███████████ ███████████ ██████████                                  
+░░███░░░░░░█░░███░░░░░░█░███░░░░███                                  
+ ░███   █ ░  ░███   █ ░ ░░░    ███                                   
+ ░███████    ░███████         ███                                    
+ ░███░░░█    ░███░░░█        ███                                     
+ ░███  ░     ░███  ░        ███                                      
+ █████       █████         ███                                       
+░░░░░       ░░░░░         ░░░                                        
+ ███████████                                      █████              
+░░███░░░░░███                                    ░░███               
+ ░███    ░███   ██████  █████████████    ██████   ░███ █████  ██████ 
+ ░██████████   ███░░███░░███░░███░░███  ░░░░░███  ░███░░███  ███░░███
+ ░███░░░░░███ ░███████  ░███ ░███ ░███   ███████  ░██████░  ░███████ 
+ ░███    ░███ ░███░░░   ░███ ░███ ░███  ███░░███  ░███░░███ ░███░░░  
+ █████   █████░░██████  █████░███ █████░░████████ ████ █████░░██████ 
+░░░░░   ░░░░░  ░░░░░░  ░░░░░ ░░░ ░░░░░  ░░░░░░░░ ░░░░ ░░░░░  ░░░░░░  
+ ███████████                      ███                                
+░█░░░███░░░█                     ░░░                                 
+░   ░███  ░  ████████   ██████   ████  ████████    ██████  ████████  
+    ░███    ░░███░░███ ░░░░░███ ░░███ ░░███░░███  ███░░███░░███░░███ 
+    ░███     ░███ ░░░   ███████  ░███  ░███ ░███ ░███████  ░███ ░░░  
+    ░███     ░███      ███░░███  ░███  ░███ ░███ ░███░░░   ░███      
+    █████    █████    ░░████████ █████ ████ █████░░██████  █████     
+   ░░░░░    ░░░░░      ░░░░░░░░ ░░░░░ ░░░░ ░░░░░  ░░░░░░  ░░░░░      
+                        - by RogueAutomata -
+                   - 100% organic LLM-free code -
+                       (for better or worse)
+```
+
 # Usage
 
 Create and activate a venv in root dir, install requirements, then run ./app/gui.py.
@@ -22,9 +52,37 @@ I've also included a pyproject.toml so you can install it as a module if preferr
 
 `trainer`
 
+# Cheats
+
+For all characters in party:
+
+- Godmode
+- Infinite MP
+- Infinite ATB
+- Infinite Limit
+- Attack boost (affects both magic and physical)
+- Luck boost
+- Give items (choose item from dropdown menu, then press `add item` hotkey)
+
+Most are available individually for Cloud as well.
+
 # Config
 
-Configure hotkeys/appearance in `settings.py`.
+Configure hotkeys/appearance in `settings.py`. Appearance options are as follows:
+
+`TRANSPARENT_BG`: If true, then the main trainer window will have an invisible background, so only the text and buttons will be visible. Ideal for overlaying the game window.
+
+`SHOW_IMAGE`: Whether or not to display the image at the top of the trainer.
+
+`HEADER_IMG_PATH`: Relative path of the image to use for above.
+
+`ALPHA`: Alpha transparency of trainer window, including text/buttons. Set between `0.0` (invisible) to `1.0` (solid). Ideal setting is around `0.8`, but this can cause issues with the trainer not being able to render on top of the game window , so I've changed the default to `1.0`.
+
+`FRAMELESS_WINDOW`: Remove the window border and maximize/minimize buttons. Ideal if you want to let the trainer stay topmost. 
+
+Fonts + font size can be changed if desired. You must have the configured fonts installed, else TkDefaultFont value will be used (Segoe UI on Windows).
+
+To edit hotkeys, see notes in `settings.py`.
 
 # Build
 

--- a/readme.md
+++ b/readme.md
@@ -28,8 +28,6 @@ A cheat trainer for FF7 Remake Intergrade.
     █████    █████    ░░████████ █████ ████ █████░░██████  █████     
    ░░░░░    ░░░░░      ░░░░░░░░ ░░░░░ ░░░░ ░░░░░  ░░░░░░  ░░░░░      
                         - by RogueAutomata -
-                   - 100% organic LLM-free code -
-                       (for better or worse)
 ```
 
 # Usage
@@ -89,6 +87,8 @@ To edit hotkeys, see notes in `settings.py`.
 This was made with the Epic store version of FF7R Intergrade. A config option is available for Steam version as well, though I have not tested it, so it may or may not work for you. (set `GAME_VERSION` to `steam` in `settings.py`) This option will change the base addresses used when reading pointers; I've done what I can to try to make it compatible + configurable without having a copy of Steam version to test on, but no guarantees here.
 
 # Build
+
+Create a venv, using Python 3.10. `py -3.10 -m venv venv'
 
 Activate venv, then run `./build_all.bat`. It will automate building with Cython, package with pyinstaller and leave an exe in `/dist`.
 

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,10 @@ Fonts + font size can be changed if desired. You must have the configured fonts 
 
 To edit hotkeys, see notes in `settings.py`.
 
+## About varying game store versions
+
+This was made with the Epic store version of FF7R Intergrade. A config option is available for Steam version as well, though I have not tested it, so it may or may not work for you. (set `GAME_VERSION` to `steam` in `settings.py`) This option will change the base addresses used when reading pointers; I've done what I can to try to make it compatible + configurable without having a copy of Steam version to test on, but no guarantees here.
+
 # Build
 
 Activate venv, then run `./build_all.bat`. It will automate building with Cython, package with pyinstaller and leave an exe in `/dist`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Cython==3.0.10
-DateTime==5.5
-keyboard==0.13.5
-logging==0.4.9.6
-Pymem==1.13.1
-pytz==2024.1
-typing==3.7.4.3
-zope.interface==6.4.post2
+Cython>=3.0.10
+DateTime>=5.5
+keyboard>=0.13.5
+logging>=0.4.9.6
+Pymem>=1.13.1
+pytz>=2024.1
+typing>=3.7.4.3
+zope.interface>=6.4.post2


### PR DESCRIPTION
1. Replace deprecated datetime.utcnow() method.
2. Change default appearance options, to avoid buggy rendering.
3. Don't lock versions of requirements.
4. Add /app dir to analysis paths in .spec file (fix module not found error when building).
5. Readme updates.
